### PR TITLE
fix(ci): resolve all failing GitHub Actions workflows

### DIFF
--- a/.dagger/main.go
+++ b/.dagger/main.go
@@ -27,7 +27,7 @@ func (m *HcpApp) buildBackendDev(source *dagger.Directory) *dagger.Container {
 		WithMountedCache("/root/.cache/uv", dag.CacheVolume("uv-cache")).
 		WithMountedDirectory("/app", backend).
 		WithWorkdir("/app").
-		WithExec([]string{"uv", "sync", "--frozen"})
+		WithExec([]string{"uv", "sync", "--frozen", "--extra", "lance"})
 }
 
 // buildFrontendDev returns a Deno container with frontend deps installed.

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -19,6 +19,7 @@ jobs:
     permissions:
       contents: read
       security-events: write
+      actions: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,8 +26,9 @@ jobs:
         with:
           python-version: 3.x
       - run: pip install zensical mkdocstrings-python
-      - run: pip install -e backend --no-deps
       - run: zensical build --clean
+        env:
+          PYTHONPATH: backend
 
       # Build Storybook and embed in docs site
       - name: Install Deno

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -12,6 +12,9 @@ permissions: read-all
 jobs:
   analysis:
     name: Scorecard analysis
+    # Scorecard uses GitHub GraphQL API which requires broader permissions
+    # than GITHUB_TOKEN provides on private repos. Auto-enables when public.
+    if: ${{ github.repository_visibility == 'public' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -31,7 +31,7 @@ jobs:
         run: deno task build-storybook
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: storybook-static
           path: frontend/storybook-static


### PR DESCRIPTION
- Add --extra lance to uv sync in Dagger so ty check can resolve lancedb
- Replace pip install -e backend with PYTHONPATH env var in docs workflow
- Add actions: read permission to CodeQL workflow for private repos
- Skip Scorecard on private repos (auto-enables when public)
- Update upload-artifact from v4 to v7 in Storybook workflow