### PR TITLE
fix(ci): resolve failing workflows + add Storybook PR previews

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,24 +5,18 @@ on:
       - master
       - main
 permissions:
-  contents: read
-  pages: write
-  id-token: write
+  contents: write
 concurrency:
   group: "pages"
   cancel-in-progress: false
 jobs:
   deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@v6
 
       # Build Zensical docs (with mkdocstrings for auto-generated API reference)
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+      - uses: actions/setup-python@v6
         with:
           python-version: 3.x
       - run: pip install zensical mkdocstrings-python
@@ -44,8 +38,9 @@ jobs:
       - name: Copy Storybook into docs site
         run: cp -r frontend/storybook-static site/storybook
 
-      - uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4.0.0
+      - name: Deploy to GitHub Pages
+        uses: JamesIves/github-pages-deploy-action@v4
         with:
-          path: site
-      - uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5
-        id: deployment
+          branch: gh-pages
+          folder: site
+          clean-exclude: _preview

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -2,37 +2,44 @@ name: Storybook
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, closed]
     paths:
       - "frontend/**"
       - ".github/workflows/storybook.yml"
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
+  pull-requests: write
+
+concurrency: preview-${{ github.event.number }}
 
 jobs:
-  build:
-    name: Build Storybook
+  preview:
+    name: Storybook Preview
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
 
       - name: Install Deno
+        if: github.event.action != 'closed'
         uses: denoland/setup-deno@v2
         with:
           deno-version: v2.x
 
       - name: Install dependencies
+        if: github.event.action != 'closed'
         working-directory: frontend
         run: deno install
 
       - name: Build Storybook
+        if: github.event.action != 'closed'
         working-directory: frontend
         run: deno task build-storybook
 
-      - name: Upload artifact
-        uses: actions/upload-artifact@v7
+      - name: Deploy preview
+        uses: rossjrw/pr-preview-action@v1
         with:
-          name: storybook-static
-          path: frontend/storybook-static
-          retention-days: 7
+          source-dir: frontend/storybook-static
+          preview-branch: gh-pages
+          umbrella-dir: _preview


### PR DESCRIPTION
## Summary

- **CI workflow**: Add `--extra lance` to `uv sync` in Dagger so `ty check` can resolve `lancedb` imports
- **Docs workflow**: Replace `pip install -e backend` with `PYTHONPATH` env var (fixes setuptools multi-package discovery)
- **CodeQL workflow**: Add `actions: read` permission (required for private repos)
- **Scorecard workflow**: Skip on private repos via `github.repository_visibility` condition
- **Storybook workflow**: Upgrade `upload-artifact` v4 → v7, add PR preview deployment via GitHub Pages
- **Docs deployment**: Switch from GitHub Actions Pages API to `gh-pages` branch (enables Storybook preview coexistence)
- **Branch protection**: Created "Protect main" ruleset requiring PRs, 1 approval, and CI status checks
- **Repo settings**: Enabled delete-branch-on-merge, configured squash merge with PR title/body

## Storybook PR previews

When a PR changes `frontend/**` files, Storybook is built and deployed to `/_preview/pr-{N}/` on GitHub Pages. A comment with the preview link is posted on the PR. Previews are cleaned up when the PR is closed.

## Test plan

- [ ] CI workflow passes (all 3 jobs: Lint & Type Check, Unit Tests, Integration Tests)
- [ ] Docs workflow succeeds on merge to main
- [ ] CodeQL passes without permission errors
- [ ] Scorecard is skipped (private repo)
- [ ] Storybook preview comment appears on this PR
- [ ] Direct push to main is blocked