### PR TITLE
fix: resolve multiple runtime bugs with real HCP instance

### DIFF
--- a/backend/app/api/v1/endpoints/s3/buckets.py
+++ b/backend/app/api/v1/endpoints/s3/buckets.py
@@ -4,7 +4,7 @@ Endpoints:
     GET  /buckets              — list all buckets
     POST /buckets              — create a bucket
     HEAD /buckets/{bucket}     — check if bucket exists
-    DELETE /buckets/{bucket}   — delete a bucket
+    DELETE /buckets/{bucket}   — delete a bucket (force=true empties first)
     GET  /buckets/{bucket}/versioning — get versioning status
     PUT  /buckets/{bucket}/versioning — set versioning
     GET  /buckets/{bucket}/acl — get bucket ACL
@@ -14,9 +14,11 @@ Endpoints:
 from __future__ import annotations
 
 import asyncio
+import logging
+from typing import Optional
 
 from botocore.exceptions import BotoCoreError, ClientError
-from fastapi import APIRouter, Depends, Response
+from fastapi import APIRouter, Depends, Query, Response
 
 from app.api.dependencies import get_s3_service
 from app.api.errors import raise_for_s3_error, raise_for_s3_transport_error, run_s3
@@ -33,6 +35,8 @@ from app.schemas.s3 import (
     VersioningMutationResponse,
 )
 from app.services.storage import StorageProtocol
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/buckets", tags=["S3 Buckets"])
 
@@ -73,10 +77,74 @@ async def head_bucket(bucket: str, s3: StorageProtocol = Depends(get_s3_service)
 
 
 @router.delete("/{bucket}", response_model=BucketMutationResponse)
-async def delete_bucket(bucket: str, s3: StorageProtocol = Depends(get_s3_service)):
-    """Delete an S3 bucket. The bucket must be empty."""
+async def delete_bucket(
+    bucket: str,
+    force: Optional[bool] = Query(None),
+    s3: StorageProtocol = Depends(get_s3_service),
+):
+    """Delete an S3 bucket.
+
+    If ``force=true``, all objects (including versions and delete markers)
+    are removed before deleting the bucket itself.
+    """
+    if force:
+        await _empty_bucket(s3, bucket)
     await run_s3(s3.delete_bucket, f"bucket '{bucket}'", bucket)
     return {"status": "deleted", "bucket": bucket}
+
+
+async def _empty_bucket(s3: StorageProtocol, bucket: str) -> None:
+    """Delete all objects, versions, and delete markers in *bucket*."""
+    deleted = 0
+
+    # 1. Delete all object versions and delete markers
+    key_marker: str | None = None
+    version_marker: str | None = None
+    while True:
+        result = await asyncio.to_thread(
+            s3.list_object_versions,
+            bucket,
+            None,  # prefix
+            1000,
+            key_marker,
+            version_marker,
+        )
+        items: list[tuple[str, str | None]] = []
+        for v in result.get("Versions", []):
+            items.append((v["Key"], v.get("VersionId")))
+        for dm in result.get("DeleteMarkers", []):
+            items.append((dm["Key"], dm.get("VersionId")))
+
+        for key, vid in items:
+            try:
+                await asyncio.to_thread(s3.delete_object, bucket, key, vid)
+                deleted += 1
+            except (ClientError, BotoCoreError) as exc:
+                logger.warning(
+                    "force-delete: failed to remove %s/%s: %s", bucket, key, exc
+                )
+
+        if not result.get("IsTruncated", False):
+            break
+        key_marker = result.get("NextKeyMarker")
+        version_marker = result.get("NextVersionIdMarker")
+
+    # 2. Clean up any remaining objects (non-versioned)
+    token: str | None = None
+    while True:
+        result = await asyncio.to_thread(s3.list_objects, bucket, None, 1000, token)
+        keys = [o["Key"] for o in result.get("Contents", [])]
+        if keys:
+            await asyncio.to_thread(s3.delete_objects, bucket, keys)
+            deleted += len(keys)
+        if not result.get("IsTruncated", False):
+            break
+        token = result.get("NextContinuationToken")
+
+    if deleted > 0:
+        logger.info(
+            "force-delete: removed %d objects from bucket '%s'", deleted, bucket
+        )
 
 
 # ── Bucket versioning ────────────────────────────────────────────────

--- a/backend/mock_server/fixtures.py
+++ b/backend/mock_server/fixtures.py
@@ -503,11 +503,14 @@ def default_tenant_settings() -> dict[str, dict]:
             "ipAddressDenylist": [],
         },
         "permissions": {
-            "namespaceCreateAllowed": True,
             "namespaceDeleteAllowed": True,
+            "namespaceManageAllowed": True,
+            "namespaceUndeleteAllowed": True,
+            "erasureCodingAllowed": True,
             "replicationAllowed": True,
             "searchAllowed": True,
             "complianceAllowed": True,
+            "taggingAllowed": True,
         },
     }
 

--- a/frontend/src/lib/components/custom/delete-confirm-dialog/delete-confirm-dialog.svelte
+++ b/frontend/src/lib/components/custom/delete-confirm-dialog/delete-confirm-dialog.svelte
@@ -6,12 +6,14 @@
 		open = $bindable(false),
 		name,
 		itemType,
+		description,
 		loading = false,
 		onconfirm,
 	}: {
 		open: boolean;
 		name: string;
 		itemType: string;
+		description?: string;
 		loading?: boolean;
 		onconfirm: () => void;
 	} = $props();
@@ -22,8 +24,12 @@
 		<AlertDialog.Header>
 			<AlertDialog.Title>Delete {itemType}</AlertDialog.Title>
 			<AlertDialog.Description>
-				Are you sure you want to delete {itemType} "<strong>{name}</strong>"? This action cannot be
-				undone.
+				{#if description}
+					{description}
+				{:else}
+					Are you sure you want to delete {itemType} "<strong>{name}</strong>"? This action cannot
+					be undone.
+				{/if}
 			</AlertDialog.Description>
 		</AlertDialog.Header>
 		<AlertDialog.Footer>

--- a/frontend/src/lib/remote/buckets.remote.ts
+++ b/frontend/src/lib/remote/buckets.remote.ts
@@ -125,17 +125,21 @@ export const create_bucket = command(
 );
 
 export const delete_bucket = command(
-  z.object({ bucket: z.string() }),
-  async ({ bucket }) => {
+  z.object({ bucket: z.string(), force: z.boolean().optional() }),
+  async ({ bucket, force }) => {
+    const qs = force ? "?force=true" : "";
     const res = await apiFetch(
-      `/api/v1/buckets/${encodeURIComponent(bucket)}`,
+      `/api/v1/buckets/${encodeURIComponent(bucket)}${qs}`,
       { method: "DELETE" },
     );
     if (!res.ok) {
       const err = await res.json().catch(() => ({
-        detail: "Failed to delete bucket",
+        detail: `Failed to delete bucket "${bucket}"`,
       }));
-      throw new Error(err.detail);
+      const detail = typeof err.detail === "string"
+        ? err.detail
+        : JSON.stringify(err.detail);
+      throw new Error(detail);
     }
   },
 );

--- a/frontend/src/lib/remote/namespaces.remote.ts
+++ b/frontend/src/lib/remote/namespaces.remote.ts
@@ -717,9 +717,12 @@ export const delete_namespace = command(
     );
     if (!res.ok) {
       const err = await res.json().catch(() => ({
-        detail: "Failed to delete namespace",
+        detail: `Failed to delete namespace "${name}"`,
       }));
-      throw new Error(err.detail);
+      const detail = typeof err.detail === "string"
+        ? err.detail
+        : JSON.stringify(err.detail);
+      throw new Error(detail);
     }
   },
 );

--- a/frontend/src/lib/utils/use-delete.svelte.ts
+++ b/frontend/src/lib/utils/use-delete.svelte.ts
@@ -27,8 +27,11 @@ export function useDelete(opts: UseDeleteOptions) {
     try {
       await deleteFn();
       toast.success(`Deleted ${opts.entityName} "${deleteTarget}"`);
-    } catch {
-      toast.error(`Failed to delete ${opts.entityName}`);
+    } catch (err) {
+      const msg = err instanceof Error
+        ? err.message
+        : `Failed to delete ${opts.entityName}`;
+      toast.error(msg);
     } finally {
       deleting = false;
       deleteDialogOpen = false;
@@ -44,12 +47,16 @@ export function useDelete(opts: UseDeleteOptions) {
     deleting = true;
     let successCount = 0;
     let failCount = 0;
+    const errors: string[] = [];
     for (let i = 0; i < names.length; i++) {
       try {
         await deleteFn(names[i], i === names.length - 1);
         successCount++;
-      } catch {
+      } catch (err) {
         failCount++;
+        if (err instanceof Error && err.message) {
+          errors.push(`${names[i]}: ${err.message}`);
+        }
       }
     }
     if (successCount > 0) {
@@ -60,11 +67,12 @@ export function useDelete(opts: UseDeleteOptions) {
       );
     }
     if (failCount > 0) {
-      toast.error(
-        `Failed to delete ${failCount} ${opts.entityName}${
+      const summary = errors.length > 0
+        ? errors.join("\n")
+        : `Failed to delete ${failCount} ${opts.entityName}${
           failCount !== 1 ? "s" : ""
-        }`,
-      );
+        }`;
+      toast.error(summary);
     }
     onDone?.();
     deleting = false;

--- a/frontend/src/routes/(app)/buckets/sections/bucket-table.svelte
+++ b/frontend/src/routes/(app)/buckets/sections/bucket-table.svelte
@@ -126,15 +126,22 @@
 	const del = useDelete({ entityName: 'bucket' });
 
 	function onConfirmDelete() {
-		del.confirmDelete(() => delete_bucket({ bucket: del.deleteTarget }).updates(bucketData));
+		del.confirmDelete(() => {
+			const queries = nsData ? [bucketData, nsData] : [bucketData];
+			return delete_bucket({ bucket: del.deleteTarget, force: true }).updates(...queries);
+		});
 	}
 
 	function onConfirmBulkDelete() {
 		del.confirmBulkDelete(
 			selectedKeys,
 			(name, isLast) => {
-				const call = delete_bucket({ bucket: name });
-				return isLast ? call.updates(bucketData) : call;
+				const call = delete_bucket({ bucket: name, force: true });
+				if (isLast) {
+					const queries = nsData ? [bucketData, nsData] : [bucketData];
+					return call.updates(...queries);
+				}
+				return call;
 			},
 			() => {
 				rowSelection = {};
@@ -347,6 +354,7 @@
 	bind:open={del.deleteDialogOpen}
 	name={del.deleteTarget}
 	itemType="bucket"
+	description={`Are you sure you want to delete bucket "${del.deleteTarget}"? All objects and versions inside will be permanently removed. This action cannot be undone.`}
 	loading={del.deleting}
 	onconfirm={onConfirmDelete}
 />

--- a/frontend/src/routes/(app)/namespaces/[namespace]/sections/ns-chargeback.svelte
+++ b/frontend/src/routes/(app)/namespaces/[namespace]/sections/ns-chargeback.svelte
@@ -183,10 +183,10 @@
 									<circle
 										cx={hoveredPoint.x}
 										cy={hoveredPoint.y}
-										r="4"
+										r="2"
 										fill="hsl(var(--primary))"
 										stroke="hsl(var(--background))"
-										stroke-width="2"
+										stroke-width="1.5"
 										vector-effect="non-scaling-stroke"
 									/>
 								{/if}

--- a/frontend/src/routes/(app)/namespaces/sections/ns-template-import.svelte
+++ b/frontend/src/routes/(app)/namespaces/sections/ns-template-import.svelte
@@ -369,7 +369,7 @@
 								{ns}
 								index={i}
 								name={importNames[i]}
-								hasConflict={existingNames.has(importNames[i])}
+								hasConflict={!importDone && !importing && existingNames.has(importNames[i])}
 								disabled={importing || importDone}
 								onnamechange={handleNameChange}
 								onnsupdate={handleNsUpdate}
@@ -413,7 +413,7 @@
 							{/each}
 						</div>
 
-						{#if nameConflicts.length > 0}
+						{#if nameConflicts.length > 0 && !importing && !importDone}
 							<div
 								class="mt-2 flex items-start gap-2 rounded-md border border-amber-400 bg-amber-50 p-2 dark:bg-amber-950/30"
 							>

--- a/frontend/src/routes/(app)/tenant-settings/sections/settings-permissions.svelte
+++ b/frontend/src/routes/(app)/tenant-settings/sections/settings-permissions.svelte
@@ -19,7 +19,6 @@
 	} = $props();
 
 	const PERMISSION_KEYS = [
-		'namespaceCreateAllowed',
 		'namespaceDeleteAllowed',
 		'namespaceManageAllowed',
 		'namespaceUndeleteAllowed',
@@ -31,7 +30,6 @@
 	] as const;
 
 	const PERMISSION_DESCRIPTIONS: Record<string, string> = {
-		namespaceCreateAllowed: 'Allow tenant users to create new namespaces',
 		namespaceDeleteAllowed: 'Allow tenant users to delete namespaces',
 		namespaceManageAllowed: 'Allow tenant users to modify namespace settings',
 		namespaceUndeleteAllowed: 'Allow recovery of deleted namespaces',


### PR DESCRIPTION
- Remove namespaceCreateAllowed from tenant permissions (not accepted by HCP)
- Add force bucket delete that empties all objects/versions before deletion
- Show actual HCP error messages in delete toasts instead of generic text
- Refresh both bucket and namespace tables after delete operations
- Suppress false "already exists" warnings during namespace template import
- Reduce oversized sparkline hover dots in chargeback charts
- Add custom description support to delete confirmation dialog