### PR TITLE
fix(frontend): include username in session cookie name

### DIFF
--- a/frontend/src/lib/components/layout/TenantSwitcher.stories.svelte
+++ b/frontend/src/lib/components/layout/TenantSwitcher.stories.svelte
@@ -22,7 +22,7 @@
 				username: 'admin',
 				exp: future,
 				expired: false,
-				cookieName: 'hcp_token__dev-ai',
+				cookieName: 'hcp_token__dev-ai__admin',
 				isActive: true,
 			},
 		],
@@ -39,7 +39,7 @@
 				username: 'admin',
 				exp: future,
 				expired: false,
-				cookieName: 'hcp_token__dev-ai',
+				cookieName: 'hcp_token__dev-ai__admin',
 				isActive: true,
 			},
 			{
@@ -47,7 +47,7 @@
 				username: 'admin',
 				exp: future,
 				expired: false,
-				cookieName: 'hcp_token__prod-ai',
+				cookieName: 'hcp_token__prod-ai__admin',
 				isActive: false,
 			},
 			{
@@ -55,7 +55,7 @@
 				username: 'operator',
 				exp: future,
 				expired: false,
-				cookieName: 'hcp_token__staging',
+				cookieName: 'hcp_token__staging__operator',
 				isActive: false,
 			},
 		],
@@ -72,7 +72,7 @@
 				username: 'admin',
 				exp: future,
 				expired: false,
-				cookieName: 'hcp_token__dev-ai',
+				cookieName: 'hcp_token__dev-ai__admin',
 				isActive: true,
 			},
 			{
@@ -80,7 +80,32 @@
 				username: 'admin',
 				exp: past,
 				expired: true,
-				cookieName: 'hcp_token__prod-ai',
+				cookieName: 'hcp_token__prod-ai__admin',
+				isActive: false,
+			},
+		],
+	}}
+/>
+
+<Story
+	name="Same Tenant Different Users"
+	args={{
+		currentTenant: 'dev-ai',
+		sessions: [
+			{
+				tenant: 'dev-ai',
+				username: 'admin',
+				exp: future,
+				expired: false,
+				cookieName: 'hcp_token__dev-ai__admin',
+				isActive: true,
+			},
+			{
+				tenant: 'dev-ai',
+				username: 'ser_accai_nsm',
+				exp: future,
+				expired: false,
+				cookieName: 'hcp_token__dev-ai__ser_accai_nsm',
 				isActive: false,
 			},
 		],
@@ -97,7 +122,7 @@
 				username: 'sysadmin',
 				exp: future,
 				expired: false,
-				cookieName: 'hcp_token____sysadmin',
+				cookieName: 'hcp_token____sysadmin__sysadmin',
 				isActive: true,
 			},
 			{
@@ -105,7 +130,7 @@
 				username: 'admin',
 				exp: future,
 				expired: false,
-				cookieName: 'hcp_token__dev-ai',
+				cookieName: 'hcp_token__dev-ai__admin',
 				isActive: false,
 			},
 		],

--- a/frontend/src/lib/server/sessions.ts
+++ b/frontend/src/lib/server/sessions.ts
@@ -9,10 +9,17 @@ const COOKIE_PREFIX = "hcp_token__";
 const ACTIVE_COOKIE = "hcp_token";
 const SYSADMIN_SLUG = "__sysadmin";
 
-function tenantToCookieName(tenant: string | undefined): string {
-  if (!tenant) return `${COOKIE_PREFIX}${SYSADMIN_SLUG}`;
-  const safe = tenant.replace(/[^a-zA-Z0-9._-]/g, "_");
-  return `${COOKIE_PREFIX}${safe}`;
+function sanitize(value: string): string {
+  return value.replace(/[^a-zA-Z0-9._-]/g, "_");
+}
+
+function sessionCookieName(
+  tenant: string | undefined,
+  username: string,
+): string {
+  const tenantPart = tenant ? sanitize(tenant) : SYSADMIN_SLUG;
+  const userPart = sanitize(username);
+  return `${COOKIE_PREFIX}${tenantPart}__${userPart}`;
 }
 
 function parseJwtPayload(token: string): Record<string, unknown> {
@@ -67,8 +74,10 @@ export function setSessionCookies(
   token: string,
   tenant: string | undefined,
 ): void {
-  const tenantCookie = tenantToCookieName(tenant);
-  cookies.set(tenantCookie, token, cookieOptions);
+  const claims = parseJwtPayload(token);
+  const username = (claims.sub as string) ?? "unknown";
+  const cookieName = sessionCookieName(tenant, username);
+  cookies.set(cookieName, token, cookieOptions);
   cookies.set(ACTIVE_COOKIE, token, cookieOptions);
 }
 


### PR DESCRIPTION
## Summary
- Cookie names were `hcp_token__{tenant}`, so logging into the same tenant with a different user overwrote the previous session
- Now uses `hcp_token__{tenant}__{username}` — multiple accounts per tenant coexist
- Adds "Same Tenant Different Users" Storybook story

## Test plan
- [x] Login as `admin` on `dev-ai`
- [x] Login as `ser_accai_nsm` on `dev-ai` (via "Add another tenant")
- [x] Verify both sessions appear in the tenant switcher dropdown
- [x] Switch between them — each should retain its own credentials
- [x] Check Storybook "Same Tenant Different Users" story renders correctly