### PR TITLE
fix: handle HCP immutable deletion records and add versioning settings UI

### DIFF
--- a/backend/app/api/v1/endpoints/s3/buckets.py
+++ b/backend/app/api/v1/endpoints/s3/buckets.py
@@ -15,13 +15,14 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from typing import Optional
+from typing import Annotated, Optional
 
 from botocore.exceptions import BotoCoreError, ClientError
-from fastapi import APIRouter, Depends, Query, Response
+from fastapi import APIRouter, Depends, HTTPException, Query, Response
 
-from app.api.dependencies import get_s3_service
+from app.api.dependencies import get_mapi_service, get_s3_service
 from app.api.errors import raise_for_s3_error, raise_for_s3_transport_error, run_s3
+from app.core.security import oauth2_scheme, verify_token_with_credentials
 from app.schemas.s3 import (
     AclPolicy,
     AclResponse,
@@ -34,6 +35,7 @@ from app.schemas.s3 import (
     PutBucketVersioningRequest,
     VersioningMutationResponse,
 )
+from app.services.mapi_service import AuthenticatedMapiService
 from app.services.storage import StorageProtocol
 
 logger = logging.getLogger(__name__)
@@ -81,23 +83,97 @@ async def delete_bucket(
     bucket: str,
     force: Optional[bool] = Query(None),
     s3: StorageProtocol = Depends(get_s3_service),
+    hcp: AuthenticatedMapiService = Depends(get_mapi_service),
+    token: Annotated[str, Depends(oauth2_scheme)] = "",
 ):
     """Delete an S3 bucket.
 
     If ``force=true``, all objects (including versions and delete markers)
-    are removed before deleting the bucket itself.
+    are removed before deleting the bucket itself.  When the S3 delete
+    fails with BucketNotEmpty (typically due to HCP's immutable deletion
+    records), the endpoint reconfigures the namespace via MAPI to allow
+    pruning of deletion records, then retries the delete.
     """
     if force:
+        creds = verify_token_with_credentials(token)
         await _empty_bucket(s3, bucket)
+        try:
+            await run_s3(s3.delete_bucket, f"bucket '{bucket}'", bucket)
+            return {"status": "deleted", "bucket": bucket}
+        except HTTPException as exc:
+            if exc.status_code != 409 or not creds.tenant:
+                raise
+
+        # BucketNotEmpty — likely immutable deletion records.
+        # Reconfigure namespace via MAPI so HCP can prune them.
+        logger.info(
+            "force-delete: S3 delete failed for '%s' (BucketNotEmpty), "
+            "reconfiguring namespace for deletion record cleanup",
+            bucket,
+        )
+        ns_path = f"/tenants/{creds.tenant}/namespaces/{bucket}"
+        await _prepare_namespace_for_delete(hcp, ns_path)
+
+        # Retry: S3 delete first, then MAPI namespace delete.
+        for attempt in range(3):
+            if attempt > 0:
+                await asyncio.sleep(2)
+            try:
+                await run_s3(s3.delete_bucket, f"bucket '{bucket}'", bucket)
+                return {"status": "deleted", "bucket": bucket}
+            except HTTPException as exc:
+                if exc.status_code != 409:
+                    raise
+            try:
+                await hcp.send("DELETE", ns_path, resource=f"bucket '{bucket}'")
+                return {"status": "deleted", "bucket": bucket}
+            except HTTPException:
+                logger.info(
+                    "force-delete: attempt %d for '%s' — waiting for "
+                    "HCP to prune deletion records",
+                    attempt + 1,
+                    bucket,
+                )
+
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                f"bucket '{bucket}': All objects removed but HCP is still "
+                f"cleaning up internal deletion records. "
+                f"Please try again in a few minutes."
+            ),
+        )
     await run_s3(s3.delete_bucket, f"bucket '{bucket}'", bucket)
     return {"status": "deleted", "bucket": bucket}
 
 
-async def _empty_bucket(s3: StorageProtocol, bucket: str) -> None:
-    """Delete all objects, versions, and delete markers in *bucket*."""
-    deleted = 0
+async def _prepare_namespace_for_delete(
+    hcp: AuthenticatedMapiService, ns_path: str
+) -> None:
+    """Reconfigure an HCP namespace so deletion records can be pruned.
 
-    # 1. Delete all object versions and delete markers
+    HCP keeps immutable "deletion records" when ``keepDeletionRecords``
+    is enabled.  These prevent both S3 bucket delete and MAPI namespace
+    delete.  To allow cleanup, we disable the record-keeping, enable
+    immediate pruning, and disable search indexing.
+    """
+    try:
+        await hcp.send(
+            "POST",
+            f"{ns_path}/versioningSettings",
+            body={"keepDeletionRecords": False, "prune": True, "pruneDays": 0},
+        )
+    except HTTPException:
+        logger.warning("force-delete: failed to update versioning settings")
+    try:
+        await hcp.send("POST", ns_path, body={"searchEnabled": False})
+    except HTTPException:
+        logger.warning("force-delete: failed to disable search")
+
+
+async def _delete_all_versions(s3: StorageProtocol, bucket: str) -> int:
+    """Delete every object version and delete marker in *bucket*."""
+    deleted = 0
     key_marker: str | None = None
     version_marker: str | None = None
     while True:
@@ -128,8 +204,17 @@ async def _empty_bucket(s3: StorageProtocol, bucket: str) -> None:
             break
         key_marker = result.get("NextKeyMarker")
         version_marker = result.get("NextVersionIdMarker")
+    return deleted
 
-    # 2. Clean up any remaining objects (non-versioned)
+
+async def _empty_bucket(s3: StorageProtocol, bucket: str) -> None:
+    """Delete all objects, versions, and delete markers in *bucket*."""
+    deleted = 0
+
+    # 1. Delete all object versions and delete markers
+    deleted += await _delete_all_versions(s3, bucket)
+
+    # 2. Clean up any remaining non-versioned objects
     token: str | None = None
     while True:
         result = await asyncio.to_thread(s3.list_objects, bucket, None, 1000, token)
@@ -140,6 +225,10 @@ async def _empty_bucket(s3: StorageProtocol, bucket: str) -> None:
         if not result.get("IsTruncated", False):
             break
         token = result.get("NextContinuationToken")
+
+    # 3. Deleting non-versioned objects may have created new delete markers
+    #    on versioned buckets — clean those up too.
+    deleted += await _delete_all_versions(s3, bucket)
 
     if deleted > 0:
         logger.info(

--- a/frontend/src/lib/components/ui/chart/chart-container.svelte
+++ b/frontend/src/lib/components/ui/chart/chart-container.svelte
@@ -17,7 +17,7 @@
 		config: ChartConfig;
 	} = $props();
 
-	const chartId = `chart-${id || uid.replace(/:/g, '')}`;
+	const chartId = $derived(`chart-${id || uid.replace(/:/g, '')}`);
 
 	setChartContext({
 		get config() {

--- a/frontend/src/lib/remote/namespaces.remote.ts
+++ b/frontend/src/lib/remote/namespaces.remote.ts
@@ -261,6 +261,59 @@ export const update_versioning = command(
   },
 );
 
+// ── Versioning Settings (MAPI) ──────────────────────────────────────
+
+export interface VersioningSettings {
+  enabled?: boolean;
+  prune?: boolean;
+  pruneDays?: number;
+  useDeleteMarkers?: boolean;
+  keepDeletionRecords?: boolean;
+}
+
+export const get_ns_versioning = query(
+  z.object({ tenant: z.string(), name: z.string() }),
+  async ({ tenant, name }) => {
+    try {
+      const res = await apiFetch(
+        `/api/v1/mapi/tenants/${tenant}/namespaces/${
+          encodeURIComponent(name)
+        }/versioningSettings`,
+      );
+      if (res.ok) return (await res.json()) as VersioningSettings;
+    } catch (err) {
+      console.error("[namespaces.remote]", err);
+    }
+    return {} as VersioningSettings;
+  },
+);
+
+export const update_ns_versioning = command(
+  z.object({
+    tenant: z.string(),
+    name: z.string(),
+    body: z.record(z.string(), z.unknown()),
+  }),
+  async ({ tenant, name, body }) => {
+    const res = await apiFetch(
+      `/api/v1/mapi/tenants/${tenant}/namespaces/${
+        encodeURIComponent(name)
+      }/versioningSettings`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      },
+    );
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({
+        detail: "Failed to update versioning settings",
+      }));
+      throw new Error(err.detail);
+    }
+  },
+);
+
 // ── Namespace Statistics ──────────────────────────────────────────────
 
 export interface NsStatistics {

--- a/frontend/src/routes/(app)/namespaces/[namespace]/+page.svelte
+++ b/frontend/src/routes/(app)/namespaces/[namespace]/+page.svelte
@@ -11,6 +11,7 @@
 	import NsUserAccess from './sections/ns-user-access.svelte';
 	import NsChargeback from './sections/ns-chargeback.svelte';
 	import NsCompliance from './sections/ns-compliance.svelte';
+	import NsVersioning from './sections/ns-versioning.svelte';
 	import NsRetentionClasses from './sections/ns-retention-classes.svelte';
 	import NsIndexing from './sections/ns-indexing.svelte';
 	import NsCors from './sections/ns-cors.svelte';
@@ -66,13 +67,14 @@
 
 				<div class="grid items-stretch gap-6 lg:grid-cols-3">
 					<NsCompliance {tenant} {namespaceName} />
-					<NsReplicationCollision {tenant} {namespaceName} />
+					<NsVersioning {tenant} {namespaceName} />
 					<NsRetentionClasses {tenant} {namespaceName} />
 				</div>
 
-				<div class="grid items-stretch gap-6 lg:grid-cols-2">
+				<div class="grid items-stretch gap-6 lg:grid-cols-3">
 					<NsIndexing {tenant} {namespaceName} />
 					<NsCors {tenant} {namespaceName} />
+					<NsReplicationCollision {tenant} {namespaceName} />
 				</div>
 			</Tabs.Content>
 		</Tabs.Root>

--- a/frontend/src/routes/(app)/namespaces/[namespace]/sections/ns-versioning.svelte
+++ b/frontend/src/routes/(app)/namespaces/[namespace]/sections/ns-versioning.svelte
@@ -1,0 +1,135 @@
+<script lang="ts">
+	import { Switch } from '$lib/components/ui/switch/index.js';
+	import { Input } from '$lib/components/ui/input/index.js';
+	import { Label } from '$lib/components/ui/label/index.js';
+	import * as Card from '$lib/components/ui/card/index.js';
+	import SaveButton from '$lib/components/custom/save-button/save-button.svelte';
+	import { useSave } from '$lib/utils/use-save.svelte.js';
+	import {
+		get_ns_versioning,
+		update_ns_versioning,
+		type VersioningSettings,
+	} from '$lib/remote/namespaces.remote.js';
+
+	let {
+		tenant,
+		namespaceName,
+	}: {
+		tenant: string;
+		namespaceName: string;
+	} = $props();
+
+	let versioningData = $derived(get_ns_versioning({ tenant, name: namespaceName }));
+	let versioning = $derived((versioningData?.current ?? {}) as VersioningSettings);
+
+	const saver = useSave({
+		successMsg: 'Versioning settings updated',
+		errorMsg: 'Failed to update versioning settings',
+	});
+
+	let localKeepDeletionRecords = $state(false);
+	let localUseDeleteMarkers = $state(false);
+	let localPrune = $state(false);
+	let localPruneDays = $state(0);
+
+	$effect(() => {
+		const v = versioning;
+		void saver.syncVersion;
+		localKeepDeletionRecords = v.keepDeletionRecords ?? false;
+		localUseDeleteMarkers = v.useDeleteMarkers ?? false;
+		localPrune = v.prune ?? false;
+		localPruneDays = v.pruneDays ?? 0;
+	});
+
+	let dirty = $derived(
+		localKeepDeletionRecords !== (versioning.keepDeletionRecords ?? false) ||
+			localUseDeleteMarkers !== (versioning.useDeleteMarkers ?? false) ||
+			localPrune !== (versioning.prune ?? false) ||
+			localPruneDays !== (versioning.pruneDays ?? 0)
+	);
+</script>
+
+<Card.Root class="flex h-full flex-col">
+	<Card.Header>
+		<Card.Title>Versioning</Card.Title>
+		<Card.Description>
+			Controls how object versions, delete markers, and deletion records are managed.
+		</Card.Description>
+	</Card.Header>
+	{#await versioningData}
+		<Card.Content class="flex-1">
+			<div class="flex flex-wrap gap-6">
+				{#each Array(4) as _, i (i)}
+					<div class="h-5 w-32 animate-pulse rounded bg-muted"></div>
+				{/each}
+			</div>
+		</Card.Content>
+	{:then}
+		<Card.Content class="flex-1 space-y-4">
+			<div class="flex flex-wrap gap-x-6 gap-y-3">
+				<div class="space-y-1.5">
+					<div class="flex items-center gap-2">
+						<Switch id="keep-deletion-records" bind:checked={localKeepDeletionRecords} />
+						<Label for="keep-deletion-records" class="text-sm">Keep Deletion Records</Label>
+					</div>
+					<p class="text-xs text-muted-foreground">
+						Retain records of delete operations for compliance auditing. Prevents bucket deletion
+						when records exist.
+					</p>
+				</div>
+				<div class="space-y-1.5">
+					<div class="flex items-center gap-2">
+						<Switch id="use-delete-markers" bind:checked={localUseDeleteMarkers} />
+						<Label for="use-delete-markers" class="text-sm">Use Delete Markers</Label>
+					</div>
+					<p class="text-xs text-muted-foreground">
+						Create delete markers when objects are deleted instead of permanently removing them.
+						Irreversible once enabled.
+					</p>
+				</div>
+			</div>
+			<div class="space-y-1.5">
+				<div class="flex items-center gap-2">
+					<Switch id="prune" bind:checked={localPrune} />
+					<Label for="prune" class="text-sm">Version Pruning</Label>
+				</div>
+				<p class="text-xs text-muted-foreground">
+					Automatically remove old object versions after the retention period.
+				</p>
+			</div>
+			<div class="space-y-1.5">
+				<Label for="prune-days">Prune After (days)</Label>
+				<Input
+					id="prune-days"
+					type="number"
+					min={0}
+					disabled={!localPrune}
+					bind:value={localPruneDays}
+				/>
+				<p class="text-xs text-muted-foreground">
+					Days to keep old versions before pruning. 0 = prune immediately.
+				</p>
+			</div>
+		</Card.Content>
+		<Card.Footer>
+			<SaveButton
+				{dirty}
+				saving={saver.saving}
+				onclick={() =>
+					saver.run(async () => {
+						if (!versioningData) return;
+						await update_ns_versioning({
+							tenant,
+							name: namespaceName,
+							body: {
+								keepDeletionRecords: localKeepDeletionRecords,
+								useDeleteMarkers: localUseDeleteMarkers,
+								prune: localPrune,
+								pruneDays: localPruneDays,
+							},
+						}).updates(versioningData);
+					})}
+			/>
+		</Card.Footer>
+	{/await}
+</Card.Root>


### PR DESCRIPTION
## Summary
- **Backend**: Force-delete now reconfigures namespace via MAPI (disable `keepDeletionRecords`, enable immediate pruning, disable search) when S3 delete fails with BucketNotEmpty due to HCP's immutable deletion records. Retries with both S3 and MAPI delete, returns clear 409 if HCP's background pruner hasn't completed.
- **Frontend**: Add versioning settings section (keepDeletionRecords, useDeleteMarkers, prune, pruneDays) to namespace settings page with MAPI remote functions.
- **Frontend**: Fix `state_referenced_locally` warning in chart-container by using `$derived` for reactive prop.

## Test plan
- [x] 415 backend tests pass
- [x] 0 errors, 0 warnings in svelte-check
- [ ] Verify versioning settings are visible and editable on namespace detail page
- [ ] Test force-delete on a bucket with deletion records