### PR TITLE
fix(frontend): default keepDeletionRecords to false on namespace creation

### DIFF
--- a/frontend/src/lib/remote/namespaces.remote.ts
+++ b/frontend/src/lib/remote/namespaces.remote.ts
@@ -88,7 +88,10 @@ export const create_namespace = command(
     if (body.hashScheme) payload.hashScheme = body.hashScheme;
     if (body.searchEnabled != null) payload.searchEnabled = body.searchEnabled;
     if (body.versioningEnabled != null) {
-      payload.versioningSettings = { enabled: body.versioningEnabled };
+      payload.versioningSettings = {
+        enabled: body.versioningEnabled,
+        keepDeletionRecords: false,
+      };
     }
     if (body.tags) payload.tags = { tag: body.tags };
     if (body.owner) {


### PR DESCRIPTION
## Summary
- When creating a namespace with versioning enabled, explicitly set `keepDeletionRecords: false`
- HCP defaults this to `true`, which creates immutable deletion records that block bucket/namespace deletion
- Users can still enable it later via the versioning settings UI if needed for compliance

## Test plan
- [ ] Create a namespace with versioning enabled, verify keepDeletionRecords is false
- [ ] Verify force-delete works on newly created namespaces