### PR TITLE
fix(frontend): align versioning settings with HCP MAPI field restrictions

### DIFF
--- a/frontend/src/lib/remote/namespaces.remote.ts
+++ b/frontend/src/lib/remote/namespaces.remote.ts
@@ -78,7 +78,6 @@ export const create_namespace = command(
     searchEnabled: z.boolean().optional(),
     versioningEnabled: z.boolean().optional(),
     keepDeletionRecords: z.boolean().optional(),
-    useDeleteMarkers: z.boolean().optional(),
     optimizedFor: z.string().optional(),
     tags: z.array(z.string()).optional(),
     owner: z.string().optional(),
@@ -95,7 +94,6 @@ export const create_namespace = command(
       payload.versioningSettings = {
         enabled: body.versioningEnabled,
         keepDeletionRecords: body.keepDeletionRecords ?? false,
-        useDeleteMarkers: body.useDeleteMarkers ?? false,
       };
     }
     if (body.tags) payload.tags = { tag: body.tags };

--- a/frontend/src/routes/(app)/namespaces/sections/namespace-create-dialog.svelte
+++ b/frontend/src/routes/(app)/namespaces/sections/namespace-create-dialog.svelte
@@ -26,7 +26,6 @@
 	let createOptimizedFor = $state('cloud');
 	let versioningEnabled = $state(false);
 	let keepDeletionRecords = $state(false);
-	let useDeleteMarkers = $state(false);
 
 	async function handleCreate(e: SubmitEvent) {
 		e.preventDefault();
@@ -55,7 +54,6 @@
 				searchEnabled,
 				versioningEnabled,
 				keepDeletionRecords: versioningEnabled ? keepDeletionRecords : undefined,
-				useDeleteMarkers: versioningEnabled ? useDeleteMarkers : undefined,
 				optimizedFor: createOptimizedFor || undefined,
 				tags: createTags.length > 0 ? createTags : undefined,
 				owner,
@@ -67,7 +65,6 @@
 			createOptimizedFor = 'cloud';
 			versioningEnabled = false;
 			keepDeletionRecords = false;
-			useDeleteMarkers = false;
 		} catch (err) {
 			createError = err instanceof Error ? err.message : 'Failed to create namespace';
 		} finally {
@@ -161,14 +158,6 @@
 					</div>
 					<p class="ml-9 text-xs text-muted-foreground">
 						Retain records of delete operations. Prevents namespace deletion when records exist.
-					</p>
-					<div class="flex items-center gap-2">
-						<Switch id="ns-delete-markers" bind:checked={useDeleteMarkers} />
-						<Label for="ns-delete-markers" class="text-sm">Use Delete Markers</Label>
-					</div>
-					<p class="ml-9 text-xs text-muted-foreground">
-						Create delete markers instead of permanently removing objects. Irreversible once
-						enabled.
 					</p>
 				</div>
 			</div>

--- a/frontend/src/routes/(app)/tenant-settings/sections/settings-namespace-defaults.svelte
+++ b/frontend/src/routes/(app)/tenant-settings/sections/settings-namespace-defaults.svelte
@@ -32,7 +32,6 @@
 	let localHashScheme = $state('');
 	let localSearchEnabled = $state(false);
 	let localVersioningEnabled = $state(false);
-	let localKeepDeletionRecords = $state(false);
 	let localUseDeleteMarkers = $state(false);
 
 	$effect(() => {
@@ -44,7 +43,6 @@
 		localHashScheme = (s?.namespaceDefaults?.hashScheme as string) ?? '';
 		localSearchEnabled = (s?.namespaceDefaults?.searchEnabled as boolean) ?? false;
 		localVersioningEnabled = (s?.namespaceDefaults?.versioningEnabled as boolean) ?? false;
-		localKeepDeletionRecords = (s?.namespaceDefaults?.keepDeletionRecords as boolean) ?? false;
 		localUseDeleteMarkers = (s?.namespaceDefaults?.useDeleteMarkers as boolean) ?? false;
 	});
 
@@ -56,8 +54,6 @@
 			localSearchEnabled !== ((settings?.namespaceDefaults?.searchEnabled as boolean) ?? false) ||
 			localVersioningEnabled !==
 				((settings?.namespaceDefaults?.versioningEnabled as boolean) ?? false) ||
-			localKeepDeletionRecords !==
-				((settings?.namespaceDefaults?.keepDeletionRecords as boolean) ?? false) ||
 			localUseDeleteMarkers !==
 				((settings?.namespaceDefaults?.useDeleteMarkers as boolean) ?? false)
 	);
@@ -123,27 +119,15 @@
 					{#if localVersioningEnabled}
 						<div class="rounded-md border bg-muted/30 p-3 space-y-3">
 							<p class="text-xs font-medium text-muted-foreground">Default Versioning Settings</p>
-							<div class="flex flex-wrap gap-x-8 gap-y-3">
-								<div class="space-y-1">
-									<div class="flex items-center gap-2">
-										<Switch id="ns-keep-deletion" bind:checked={localKeepDeletionRecords} />
-										<Label for="ns-keep-deletion" class="text-sm">Keep Deletion Records</Label>
-									</div>
-									<p class="ml-9 text-xs text-muted-foreground">
-										Retain records of delete operations. Prevents namespace deletion when records
-										exist.
-									</p>
+							<div class="space-y-1">
+								<div class="flex items-center gap-2">
+									<Switch id="ns-delete-markers" bind:checked={localUseDeleteMarkers} />
+									<Label for="ns-delete-markers" class="text-sm">Use Delete Markers</Label>
 								</div>
-								<div class="space-y-1">
-									<div class="flex items-center gap-2">
-										<Switch id="ns-delete-markers" bind:checked={localUseDeleteMarkers} />
-										<Label for="ns-delete-markers" class="text-sm">Use Delete Markers</Label>
-									</div>
-									<p class="ml-9 text-xs text-muted-foreground">
-										Create delete markers instead of permanently removing objects. Irreversible once
-										enabled.
-									</p>
-								</div>
+								<p class="ml-9 text-xs text-muted-foreground">
+									Create delete markers instead of permanently removing objects. Irreversible once
+									enabled.
+								</p>
 							</div>
 						</div>
 					{/if}
@@ -162,7 +146,6 @@
 										hashScheme: localHashScheme,
 										searchEnabled: localSearchEnabled,
 										versioningEnabled: localVersioningEnabled,
-										keepDeletionRecords: localKeepDeletionRecords,
 										useDeleteMarkers: localUseDeleteMarkers,
 									},
 								}).updates(settingsData);


### PR DESCRIPTION
## Summary
- Fix `Invalid fields supplied: [useDeleteMarkers]` error on namespace creation
- Per HCP MAPI docs:
  - `useDeleteMarkers` is NOT valid on namespace create PUT → removed from create dialog
  - `keepDeletionRecords` is NOT valid on namespace defaults POST → removed from tenant defaults
- Create dialog: `optimizedFor` select + `keepDeletionRecords` switch (when versioning enabled)
- Tenant defaults: `useDeleteMarkers` switch (when versioning enabled)

## Test plan
- [ ] Create namespace with versioning enabled — no error
- [ ] Tenant defaults: save with useDeleteMarkers toggle — no error
- [ ] Verify keepDeletionRecords works in namespace create