### PR TITLE
feat: make force delete opt-in for bucket deletion

### DIFF
--- a/frontend/src/lib/components/custom/bulk-delete-dialog/bulk-delete-dialog.stories.svelte
+++ b/frontend/src/lib/components/custom/bulk-delete-dialog/bulk-delete-dialog.stories.svelte
@@ -23,3 +23,8 @@
 <Story name="Loading" args={{ loading: true }} />
 
 <Story name="Objects" args={{ count: 12, itemType: 'object' }} />
+
+<Story
+	name="Buckets with Force Option"
+	args={{ count: 3, itemType: 'bucket', showForceOption: true }}
+/>

--- a/frontend/src/lib/components/custom/bulk-delete-dialog/bulk-delete-dialog.svelte
+++ b/frontend/src/lib/components/custom/bulk-delete-dialog/bulk-delete-dialog.svelte
@@ -1,22 +1,32 @@
 <script lang="ts">
 	import * as AlertDialog from '$lib/components/ui/alert-dialog/index.js';
 	import { Button } from '$lib/components/ui/button/index.js';
+	import { Checkbox } from '$lib/components/ui/checkbox/index.js';
 
 	let {
 		open = $bindable(false),
+		force = $bindable(false),
 		count,
 		itemType,
 		loading = false,
+		showForceOption = false,
 		onconfirm,
 	}: {
 		open: boolean;
+		force?: boolean;
 		count: number;
 		itemType: string;
 		loading?: boolean;
+		showForceOption?: boolean;
 		onconfirm: () => void;
 	} = $props();
 
 	let plural = $derived(count !== 1 ? 's' : '');
+
+	// Reset force when dialog closes
+	$effect(() => {
+		if (!open) force = false;
+	});
 </script>
 
 <AlertDialog.Root bind:open>
@@ -27,6 +37,14 @@
 				Are you sure you want to delete {count}
 				{itemType}{plural}? This action cannot be undone.
 			</AlertDialog.Description>
+			{#if showForceOption}
+				<label class="mt-3 flex items-center gap-2">
+					<Checkbox bind:checked={force} disabled={loading} />
+					<span class="text-sm text-muted-foreground">
+						Force delete — empties bucket and overrides versioning protection settings
+					</span>
+				</label>
+			{/if}
 		</AlertDialog.Header>
 		<AlertDialog.Footer>
 			<AlertDialog.Cancel disabled={loading}>Cancel</AlertDialog.Cancel>

--- a/frontend/src/lib/components/custom/delete-confirm-dialog/delete-confirm-dialog.stories.svelte
+++ b/frontend/src/lib/components/custom/delete-confirm-dialog/delete-confirm-dialog.stories.svelte
@@ -23,3 +23,8 @@
 <Story name="User" args={{ name: 'john.doe', itemType: 'user' }} />
 
 <Story name="Bucket" args={{ name: 'backup-2024', itemType: 'bucket' }} />
+
+<Story
+	name="Bucket with Force Option"
+	args={{ name: 'backup-2024', itemType: 'bucket', showForceOption: true }}
+/>

--- a/frontend/src/lib/components/custom/delete-confirm-dialog/delete-confirm-dialog.svelte
+++ b/frontend/src/lib/components/custom/delete-confirm-dialog/delete-confirm-dialog.svelte
@@ -1,22 +1,32 @@
 <script lang="ts">
 	import * as AlertDialog from '$lib/components/ui/alert-dialog/index.js';
 	import { Button } from '$lib/components/ui/button/index.js';
+	import { Checkbox } from '$lib/components/ui/checkbox/index.js';
 
 	let {
 		open = $bindable(false),
+		force = $bindable(false),
 		name,
 		itemType,
 		description,
 		loading = false,
+		showForceOption = false,
 		onconfirm,
 	}: {
 		open: boolean;
+		force?: boolean;
 		name: string;
 		itemType: string;
 		description?: string;
 		loading?: boolean;
+		showForceOption?: boolean;
 		onconfirm: () => void;
 	} = $props();
+
+	// Reset force when dialog closes
+	$effect(() => {
+		if (!open) force = false;
+	});
 </script>
 
 <AlertDialog.Root bind:open>
@@ -31,6 +41,14 @@
 					be undone.
 				{/if}
 			</AlertDialog.Description>
+			{#if showForceOption}
+				<label class="mt-3 flex items-center gap-2">
+					<Checkbox bind:checked={force} disabled={loading} />
+					<span class="text-sm text-muted-foreground">
+						Force delete — empties bucket and overrides versioning protection settings
+					</span>
+				</label>
+			{/if}
 		</AlertDialog.Header>
 		<AlertDialog.Footer>
 			<AlertDialog.Cancel disabled={loading}>Cancel</AlertDialog.Cancel>

--- a/frontend/src/routes/(app)/buckets/sections/bucket-table.svelte
+++ b/frontend/src/routes/(app)/buckets/sections/bucket-table.svelte
@@ -124,11 +124,13 @@
 	let selectedCount = $derived(selectedKeys.length);
 
 	const del = useDelete({ entityName: 'bucket' });
+	let forceDelete = $state(false);
+	let forceBulkDelete = $state(false);
 
 	function onConfirmDelete() {
 		del.confirmDelete(() => {
 			const queries = nsData ? [bucketData, nsData] : [bucketData];
-			return delete_bucket({ bucket: del.deleteTarget, force: true }).updates(...queries);
+			return delete_bucket({ bucket: del.deleteTarget, force: forceDelete }).updates(...queries);
 		});
 	}
 
@@ -136,7 +138,7 @@
 		del.confirmBulkDelete(
 			selectedKeys,
 			(name, isLast) => {
-				const call = delete_bucket({ bucket: name, force: true });
+				const call = delete_bucket({ bucket: name, force: forceBulkDelete });
 				if (isLast) {
 					const queries = nsData ? [bucketData, nsData] : [bucketData];
 					return call.updates(...queries);
@@ -352,17 +354,21 @@
 
 <DeleteConfirmDialog
 	bind:open={del.deleteDialogOpen}
+	bind:force={forceDelete}
 	name={del.deleteTarget}
 	itemType="bucket"
-	description={`Are you sure you want to delete bucket "${del.deleteTarget}"? All objects and versions inside will be permanently removed. This action cannot be undone.`}
+	description={`Are you sure you want to delete bucket "${del.deleteTarget}"? This action cannot be undone.`}
+	showForceOption
 	loading={del.deleting}
 	onconfirm={onConfirmDelete}
 />
 
 <BulkDeleteDialog
 	bind:open={del.bulkDeleteOpen}
+	bind:force={forceBulkDelete}
 	count={selectedCount}
 	itemType="bucket"
+	showForceOption
 	loading={del.deleting}
 	onconfirm={onConfirmBulkDelete}
 />


### PR DESCRIPTION
## Summary
- Bucket delete no longer hardcodes `force: true` — force-delete is now opt-in via a checkbox in both single and bulk delete dialogs
- Prevents silently emptying buckets and overriding namespace versioning protection settings (`keepDeletionRecords`, `prune`, `searchEnabled`)
- Both `DeleteConfirmDialog` and `BulkDeleteDialog` gain optional `showForceOption` + `force` props (fully backwards-compatible — existing consumers unaffected)

## Test plan
- [ ] Delete an empty bucket WITHOUT force checked → should succeed
- [ ] Delete a non-empty bucket WITHOUT force → should fail with clear error
- [ ] Delete a non-empty bucket WITH force checked → should succeed (empties + deletes)
- [ ] Bulk delete with force checkbox → applies to all selected buckets
- [ ] Force checkbox resets when dialog closes and reopens
- [ ] Verify other delete dialogs (users, namespaces, content classes) still work without changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)