### PR TITLE
feat: add tenant Operations tab and versioning reset

### DIFF
--- a/backend/app/core/telemetry.py
+++ b/backend/app/core/telemetry.py
@@ -59,7 +59,8 @@ class JSONFormatter(logging.Formatter):
         return _json.dumps(entry, default=str)
 
 
-_resource = Resource.create({"service.name": "hcp-api"})
+_service_name = os.getenv("OTEL_SERVICE_NAME", "ra-hcp")
+_resource = Resource.create({"service.name": _service_name})
 
 
 def setup_telemetry(app: FastAPI) -> None:
@@ -69,7 +70,7 @@ def setup_telemetry(app: FastAPI) -> None:
     tracer_provider = TracerProvider(resource=_resource)
 
     if os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT"):
-        from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import (
+        from opentelemetry.exporter.otlp.proto.http.trace_exporter import (
             OTLPSpanExporter,
         )
 
@@ -81,7 +82,7 @@ def setup_telemetry(app: FastAPI) -> None:
 
     # ── Metrics provider ──────────────────────────────────────────────
     if os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT"):
-        from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import (
+        from opentelemetry.exporter.otlp.proto.http.metric_exporter import (
             OTLPMetricExporter,
         )
         from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
@@ -115,4 +116,6 @@ def setup_telemetry(app: FastAPI) -> None:
     logging.root.handlers.clear()
     logging.root.addHandler(handler)
     logging.root.setLevel(logging.INFO)
-    logging.getLogger(__name__).info("Telemetry initialised (service.name=hcp-api)")
+    logging.getLogger(__name__).info(
+        "Telemetry initialised (service.name=%s)", _service_name
+    )

--- a/backend/mock_server/fixtures.py
+++ b/backend/mock_server/fixtures.py
@@ -16,6 +16,11 @@ TENANTS: dict[str, dict] = {
         "namespaceQuota": "10",
         "authenticationTypes": {"authenticationType": ["LOCAL"]},
         "tags": {"tag": []},
+        "administrationAllowed": True,
+        "maxNamespacesPerUser": 100,
+        "snmpLoggingEnabled": False,
+        "syslogLoggingEnabled": False,
+        "tenantVisibleDescription": "",
     },
     "research": {
         "name": "research",
@@ -25,6 +30,11 @@ TENANTS: dict[str, dict] = {
         "namespaceQuota": "20",
         "authenticationTypes": {"authenticationType": ["LOCAL"]},
         "tags": {"tag": []},
+        "administrationAllowed": True,
+        "maxNamespacesPerUser": 100,
+        "snmpLoggingEnabled": False,
+        "syslogLoggingEnabled": False,
+        "tenantVisibleDescription": "",
     },
     "mock": {
         "name": "mock",
@@ -35,6 +45,11 @@ TENANTS: dict[str, dict] = {
         "authenticationTypes": {"authenticationType": ["LOCAL"]},
         "servicePlan": "Default",
         "tags": {"tag": []},
+        "administrationAllowed": True,
+        "maxNamespacesPerUser": 100,
+        "snmpLoggingEnabled": False,
+        "syslogLoggingEnabled": True,
+        "tenantVisibleDescription": "Mock tenant for local development and testing.",
     },
 }
 

--- a/frontend/src/lib/remote/namespaces.remote.ts
+++ b/frontend/src/lib/remote/namespaces.remote.ts
@@ -320,6 +320,24 @@ export const update_ns_versioning = command(
   },
 );
 
+export const delete_ns_versioning = command(
+  z.object({ tenant: z.string(), name: z.string() }),
+  async ({ tenant, name }) => {
+    const res = await apiFetch(
+      `/api/v1/mapi/tenants/${tenant}/namespaces/${
+        encodeURIComponent(name)
+      }/versioningSettings`,
+      { method: "DELETE" },
+    );
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({
+        detail: "Failed to reset versioning settings",
+      }));
+      throw new Error(err.detail);
+    }
+  },
+);
+
 // ── Namespace Statistics ──────────────────────────────────────────────
 
 export interface NsStatistics {

--- a/frontend/src/lib/remote/tenant-info.remote.ts
+++ b/frontend/src/lib/remote/tenant-info.remote.ts
@@ -394,6 +394,34 @@ export const delete_tenant_cors = command(
   },
 );
 
+// ── Tenant Operations (top-level POST) ──────────────────────────────
+
+export interface TenantOperations {
+  administrationAllowed?: boolean;
+  maxNamespacesPerUser?: number;
+  snmpLoggingEnabled?: boolean;
+  syslogLoggingEnabled?: boolean;
+  tenantVisibleDescription?: string;
+  tags?: Record<string, unknown>;
+}
+
+export const update_tenant = command(
+  z.object({ tenant: z.string(), body: z.record(z.string(), z.unknown()) }),
+  async ({ tenant, body }) => {
+    const res = await apiFetch(`/api/v1/mapi/tenants/${tenant}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({
+        detail: "Failed to update tenant settings",
+      }));
+      throw new Error(err.detail);
+    }
+  },
+);
+
 // ── Available Service Plans ──────────────────────────────────────────
 
 export interface ServicePlanList {

--- a/frontend/src/routes/(app)/namespaces/[namespace]/sections/ns-versioning.svelte
+++ b/frontend/src/routes/(app)/namespaces/[namespace]/sections/ns-versioning.svelte
@@ -2,12 +2,16 @@
 	import { Switch } from '$lib/components/ui/switch/index.js';
 	import { Input } from '$lib/components/ui/input/index.js';
 	import { Label } from '$lib/components/ui/label/index.js';
+	import { Button } from '$lib/components/ui/button/index.js';
 	import * as Card from '$lib/components/ui/card/index.js';
+	import * as AlertDialog from '$lib/components/ui/alert-dialog/index.js';
 	import SaveButton from '$lib/components/custom/save-button/save-button.svelte';
 	import { useSave } from '$lib/utils/use-save.svelte.js';
+	import { toast } from 'svelte-sonner';
 	import {
 		get_ns_versioning,
 		update_ns_versioning,
+		delete_ns_versioning,
 		type VersioningSettings,
 	} from '$lib/remote/namespaces.remote.js';
 
@@ -47,6 +51,23 @@
 			localPrune !== (versioning.prune ?? false) ||
 			localPruneDays !== (versioning.pruneDays ?? 0)
 	);
+
+	let resetOpen = $state(false);
+	let resetting = $state(false);
+
+	async function handleReset() {
+		resetting = true;
+		try {
+			if (!versioningData) return;
+			await delete_ns_versioning({ tenant, name: namespaceName }).updates(versioningData);
+			toast.success('Versioning settings reset to defaults');
+			resetOpen = false;
+		} catch (err) {
+			toast.error(err instanceof Error ? err.message : 'Failed to reset versioning settings');
+		} finally {
+			resetting = false;
+		}
+	}
 </script>
 
 <Card.Root class="flex h-full flex-col">
@@ -111,7 +132,10 @@
 				</p>
 			</div>
 		</Card.Content>
-		<Card.Footer>
+		<Card.Footer class="flex justify-between">
+			<Button variant="outline" size="sm" onclick={() => (resetOpen = true)}>
+				Reset to Defaults
+			</Button>
 			<SaveButton
 				{dirty}
 				saving={saver.saving}
@@ -133,3 +157,22 @@
 		</Card.Footer>
 	{/await}
 </Card.Root>
+
+<AlertDialog.Root bind:open={resetOpen}>
+	<AlertDialog.Content>
+		<AlertDialog.Header>
+			<AlertDialog.Title>Reset Versioning Settings</AlertDialog.Title>
+			<AlertDialog.Description>
+				This will remove all versioning configuration for namespace "<strong>{namespaceName}</strong
+				>" and revert to no-versioning state. All settings (pruning, delete markers, deletion
+				records) will be cleared.
+			</AlertDialog.Description>
+		</AlertDialog.Header>
+		<AlertDialog.Footer>
+			<AlertDialog.Cancel disabled={resetting}>Cancel</AlertDialog.Cancel>
+			<Button variant="destructive" onclick={handleReset} disabled={resetting}>
+				{resetting ? 'Resetting...' : 'Reset'}
+			</Button>
+		</AlertDialog.Footer>
+	</AlertDialog.Content>
+</AlertDialog.Root>

--- a/frontend/src/routes/(app)/tenant-settings/+page.svelte
+++ b/frontend/src/routes/(app)/tenant-settings/+page.svelte
@@ -11,6 +11,7 @@
 		Search,
 		Globe,
 		CreditCard,
+		Wrench,
 	} from 'lucide-svelte';
 	import PageHeader from '$lib/components/custom/page-header/page-header.svelte';
 	import NoTenantPlaceholder from '$lib/components/custom/no-tenant-placeholder/no-tenant-placeholder.svelte';
@@ -23,6 +24,7 @@
 	import SettingsSearchSecurity from './sections/settings-search-security.svelte';
 	import SettingsCors from './sections/settings-cors.svelte';
 	import SettingsServicePlans from './sections/settings-service-plans.svelte';
+	import SettingsOperations from './sections/settings-operations.svelte';
 
 	let tenant = $derived(page.data.tenant as string | undefined);
 	let activeTab = $state('general');
@@ -77,6 +79,10 @@
 					<CreditCard class="mr-1.5 h-4 w-4" />
 					Service Plans
 				</Tabs.Trigger>
+				<Tabs.Trigger value="operations">
+					<Wrench class="mr-1.5 h-4 w-4" />
+					Operations
+				</Tabs.Trigger>
 			</Tabs.List>
 
 			<Tabs.Content value="general">
@@ -113,6 +119,10 @@
 
 			<Tabs.Content value="service-plans">
 				<SettingsServicePlans {tenant} />
+			</Tabs.Content>
+
+			<Tabs.Content value="operations">
+				<SettingsOperations {tenant} />
 			</Tabs.Content>
 		</Tabs.Root>
 	{:else}

--- a/frontend/src/routes/(app)/tenant-settings/sections/settings-operations.svelte
+++ b/frontend/src/routes/(app)/tenant-settings/sections/settings-operations.svelte
@@ -1,0 +1,151 @@
+<script lang="ts">
+	import { Switch } from '$lib/components/ui/switch/index.js';
+	import { Input } from '$lib/components/ui/input/index.js';
+	import { Label } from '$lib/components/ui/label/index.js';
+	import { Textarea } from '$lib/components/ui/textarea/index.js';
+	import * as Card from '$lib/components/ui/card/index.js';
+	import CardSkeleton from '$lib/components/ui/skeleton/card-skeleton.svelte';
+	import SaveButton from '$lib/components/custom/save-button/save-button.svelte';
+	import { useSave } from '$lib/utils/use-save.svelte.js';
+	import { get_tenant, update_tenant, type TenantInfo } from '$lib/remote/tenant-info.remote.js';
+
+	let {
+		tenant,
+	}: {
+		tenant: string;
+	} = $props();
+
+	let tenantData = $derived(get_tenant({ tenant }));
+	let info = $derived((tenantData?.current ?? {}) as TenantInfo & Record<string, unknown>);
+
+	const saver = useSave({
+		successMsg: 'Operational settings updated',
+		errorMsg: 'Failed to update operational settings',
+	});
+
+	let localAdministrationAllowed = $state(true);
+	let localMaxNamespacesPerUser = $state(100);
+	let localSnmpLoggingEnabled = $state(false);
+	let localSyslogLoggingEnabled = $state(false);
+	let localTenantVisibleDescription = $state('');
+
+	$effect(() => {
+		const t = info;
+		void saver.syncVersion;
+		localAdministrationAllowed = (t.administrationAllowed as boolean) ?? true;
+		localMaxNamespacesPerUser = (t.maxNamespacesPerUser as number) ?? 100;
+		localSnmpLoggingEnabled = (t.snmpLoggingEnabled as boolean) ?? false;
+		localSyslogLoggingEnabled = (t.syslogLoggingEnabled as boolean) ?? false;
+		localTenantVisibleDescription = (t.tenantVisibleDescription as string) ?? '';
+	});
+
+	let dirty = $derived(
+		localAdministrationAllowed !== ((info.administrationAllowed as boolean) ?? true) ||
+			localMaxNamespacesPerUser !== ((info.maxNamespacesPerUser as number) ?? 100) ||
+			localSnmpLoggingEnabled !== ((info.snmpLoggingEnabled as boolean) ?? false) ||
+			localSyslogLoggingEnabled !== ((info.syslogLoggingEnabled as boolean) ?? false) ||
+			localTenantVisibleDescription !== ((info.tenantVisibleDescription as string) ?? '')
+	);
+</script>
+
+{#await tenantData}
+	<CardSkeleton />
+{:then}
+	<Card.Root>
+		<Card.Header>
+			<Card.Title>Operations</Card.Title>
+			<Card.Description>
+				Tenant-level operational settings including logging, administration, and namespace limits
+			</Card.Description>
+		</Card.Header>
+		<Card.Content>
+			<div class="space-y-6">
+				<div class="space-y-4">
+					<h4 class="text-sm font-medium">Log Forwarding</h4>
+					<p class="text-xs text-muted-foreground">
+						Forward tenant log messages to the syslog servers and SNMP managers configured at the
+						HCP system level. Destinations are managed by the system administrator.
+					</p>
+					<div class="flex flex-wrap gap-x-8 gap-y-4">
+						<div class="space-y-1.5">
+							<div class="flex items-center gap-2">
+								<Switch id="syslog-logging" bind:checked={localSyslogLoggingEnabled} />
+								<Label for="syslog-logging" class="text-sm">Syslog</Label>
+							</div>
+						</div>
+						<div class="space-y-1.5">
+							<div class="flex items-center gap-2">
+								<Switch id="snmp-logging" bind:checked={localSnmpLoggingEnabled} />
+								<Label for="snmp-logging" class="text-sm">SNMP</Label>
+							</div>
+						</div>
+					</div>
+				</div>
+
+				<hr class="border-border" />
+
+				<div class="space-y-4">
+					<h4 class="text-sm font-medium">Administration</h4>
+					<div class="space-y-1.5">
+						<div class="flex items-center gap-2">
+							<Switch id="administration-allowed" bind:checked={localAdministrationAllowed} />
+							<Label for="administration-allowed" class="text-sm">
+								Allow System-Level Administration
+							</Label>
+						</div>
+						<p class="text-xs text-muted-foreground">
+							Enables system-level administrative access to this tenant.
+						</p>
+					</div>
+					<div class="space-y-2">
+						<Label for="max-ns-per-user">Max Namespaces Per User</Label>
+						<Input
+							id="max-ns-per-user"
+							type="number"
+							min={0}
+							max={10000}
+							bind:value={localMaxNamespacesPerUser}
+						/>
+						<p class="text-xs text-muted-foreground">
+							Maximum number of namespaces any single user can own (0–10,000).
+						</p>
+					</div>
+				</div>
+
+				<hr class="border-border" />
+
+				<div class="space-y-2">
+					<Label for="tenant-description">Tenant Description</Label>
+					<Textarea
+						id="tenant-description"
+						bind:value={localTenantVisibleDescription}
+						placeholder="Optional description visible to tenant users"
+						rows={3}
+					/>
+					<p class="text-xs text-muted-foreground">
+						A description visible to users of this tenant. Up to 1,024 characters.
+					</p>
+				</div>
+
+				<SaveButton
+					{dirty}
+					saving={saver.saving}
+					onclick={() =>
+						saver.run(async () => {
+							if (!tenantData) return;
+							await update_tenant({
+								tenant,
+								body: {
+									administrationAllowed: localAdministrationAllowed,
+									maxNamespacesPerUser: localMaxNamespacesPerUser,
+									snmpLoggingEnabled: localSnmpLoggingEnabled,
+									syslogLoggingEnabled: localSyslogLoggingEnabled,
+									tenantVisibleDescription: localTenantVisibleDescription,
+								},
+							}).updates(tenantData);
+						})}
+				/>
+			</div>
+		</Card.Content>
+	</Card.Root>
+{/await}


### PR DESCRIPTION
## Summary
- Adds **Operations** tab to Tenant Settings with syslog/SNMP log forwarding toggles, system administration toggle, max-namespaces-per-user limit, and tenant description textarea
- Adds **Reset to Defaults** button to namespace versioning card (DELETE versioningSettings) with AlertDialog confirmation
- Adds `update_tenant` and `delete_ns_versioning` remote functions
- Seeds mock fixtures with operational fields for local dev

## Test plan
- [ ] Navigate to Tenant Settings > Operations tab — verify toggles and inputs render with mock data
- [ ] Toggle syslog/SNMP, change max namespaces, edit description — verify dirty state and save works
- [ ] Navigate to any namespace > Settings > Versioning card — verify "Reset to Defaults" button appears
- [ ] Click Reset to Defaults — verify confirmation dialog, then verify settings clear after confirm
- [ ] Run `make quality` — passes with 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)