### PR TITLE
fix(frontend): add missing useCopyFeedback composable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -119,8 +119,11 @@ CORS_ORIGINS=                            # comma-separated, empty = allow all
 # ── OpenTelemetry (optional) ────────────────────────────────────────
 # When set, traces and metrics are exported via OTLP gRPC to this endpoint.
 # When empty, traces go to console (stdout) and metrics are disabled.
-OTEL_EXPORTER_OTLP_ENDPOINT=       # e.g. http://localhost:4317
-OTEL_SERVICE_NAME=hcp-api           # service.name resource attribute
+OTEL_SERVICE_NAME="ra-hcp"                                                                                     
+OTEL_EXPORTER_OTLP_ENDPOINT="https://otlp-gateway-prod-eu-north-0.grafana.net/otlp"                            
+OTEL_EXPORTER_OTLP_PROTOCOL="http/protobuf"                                                                    
+OTEL_RESOURCE_ATTRIBUTES="deployment.environment=dev"                                                          
+OTEL_EXPORTER_OTLP_HEADERS="=<Auth>" 
 
 # ── Redis Cache (optional) ──────────────────────────────────────────
 REDIS_URL=                  # empty = no caching (e.g. redis://localhost:6379)
@@ -134,3 +137,5 @@ CACHE_KEY_PREFIX=hcp
 # ── Frontend (SvelteKit) ──────────────────────────────────────────
 BACKEND_URL=http://127.0.0.1:8000    # backend API URL for SvelteKit server
 COOKIE_SECURE=                        # true|false, defaults to true in prod / false in dev
+
+

--- a/frontend/src/lib/utils/use-copy-feedback.svelte.ts
+++ b/frontend/src/lib/utils/use-copy-feedback.svelte.ts
@@ -1,0 +1,37 @@
+import { onDestroy } from "svelte";
+
+export function useCopyFeedback(duration = 2000) {
+  let copied = $state(false);
+  let timer: ReturnType<typeof setTimeout> | undefined;
+
+  function cleanup() {
+    clearTimeout(timer);
+  }
+
+  async function copy(value: string) {
+    try {
+      await navigator.clipboard.writeText(value);
+    } catch {
+      const ta = document.createElement("textarea");
+      ta.value = value;
+      ta.style.position = "fixed";
+      ta.style.opacity = "0";
+      document.body.appendChild(ta);
+      ta.select();
+      document.execCommand("copy");
+      document.body.removeChild(ta);
+    }
+    cleanup();
+    copied = true;
+    timer = setTimeout(() => (copied = false), duration);
+  }
+
+  onDestroy(cleanup);
+
+  return {
+    get copied() {
+      return copied;
+    },
+    copy,
+  };
+}


### PR DESCRIPTION
## Summary
- Add the `use-copy-feedback.svelte.ts` composable that was referenced by memory leak fixes in the prior commit but not included
- Update `.env.example` with OTLP HTTP/protobuf configuration fields for Grafana Cloud

## Context
The prior commit (`b253d26`) fixed memory leaks across 8 frontend files by introducing a shared `useCopyFeedback` composable, but the composable file itself was accidentally omitted from that commit.