### PR TITLE
fix(docs): update zensical config with correct branding and missing extensions

### DIFF
--- a/zensical.toml
+++ b/zensical.toml
@@ -1,11 +1,14 @@
 [project]
-site_name = "HCP App"
+site_name = "ra-hcp"
+site_url = "https://ai-riksarkivet.github.io/hcp/"
 site_description = "Hitachi Content Platform application — unified FastAPI service for S3-compatible object storage and HCP Management API operations."
-site_author = "HCP App Team"
-copyright = "Copyright &copy; 2026 HCP App"
+site_author = "AI-Riksarkivet"
+copyright = "Copyright &copy; 2026 AI-Riksarkivet"
+repo_url = "https://github.com/AI-Riksarkivet/hcp"
+repo_name = "AI-Riksarkivet/hcp"
 
 nav = [
-  { "HCP App" = [
+  { "ra-hcp" = [
     "index.md",
   ]},
   { "Getting Started" = [
@@ -47,8 +50,17 @@ extra_css = ["stylesheets/extra.css"]
 # ----------------------------------------------------------------------------
 [project.theme]
 language = "en"
+custom_dir = "docs/overrides"
+logo = "assets/ra.svg"
+favicon = "assets/favicon.ico"
+
+[project.theme.icon]
+repo = "fontawesome/brands/github"
 
 features = [
+    "announce.dismiss",
+    "content.action.edit",
+    "content.action.view",
     "content.code.annotate",
     "content.code.copy",
     "content.code.select",
@@ -86,10 +98,41 @@ toggle.name = "Switch to light mode"
 # ----------------------------------------------------------------------------
 # Markdown extensions
 # ----------------------------------------------------------------------------
+# NOTE: Defining any extensions overrides Zensical defaults, so we must
+# explicitly list all extensions we need (admonition, tables, toc, etc.).
+[project.markdown_extensions.abbr]
+[project.markdown_extensions.admonition]
+[project.markdown_extensions.attr_list]
+[project.markdown_extensions.def_list]
+[project.markdown_extensions.footnotes]
+[project.markdown_extensions.md_in_html]
+[project.markdown_extensions.tables]
+[project.markdown_extensions.toc]
+permalink = true
+
+[project.markdown_extensions.pymdownx.betterem]
+smart_enable = "all"
+[project.markdown_extensions.pymdownx.caret]
+[project.markdown_extensions.pymdownx.details]
+[project.markdown_extensions.pymdownx.emoji]
+emoji_generator = "zensical.extensions.emoji.to_svg"
+emoji_index = "zensical.extensions.emoji.twemoji"
+[project.markdown_extensions.pymdownx.highlight]
+[project.markdown_extensions.pymdownx.inlinehilite]
+[project.markdown_extensions.pymdownx.keys]
+[project.markdown_extensions.pymdownx.mark]
+[project.markdown_extensions.pymdownx.smartsymbols]
+[project.markdown_extensions.pymdownx.snippets]
+base_path = ["."]
 [project.markdown_extensions.pymdownx.superfences]
 custom_fences = [
   { name = "mermaid", class = "mermaid", format = "pymdownx.superfences.fence_code_format" },
 ]
+[project.markdown_extensions.pymdownx.tabbed]
+alternate_style = true
+[project.markdown_extensions.pymdownx.tasklist]
+custom_checkbox = true
+[project.markdown_extensions.pymdownx.tilde]
 
 # ----------------------------------------------------------------------------
 # Plugins — mkdocstrings (auto-generated API reference from source)


### PR DESCRIPTION
## Summary
- Rename site from "HCP App" to "ra-hcp" with AI-Riksarkivet branding
- Add `ra.svg` logo and `favicon.ico` to theme config
- Add `repo_url` with GitHub icon in the header (beside search)
- Add `pymdownx.snippets` with `base_path = ["."]` to fix `--8<-- "README.md"` ingestion in `docs/index.md`
- Restore all default markdown extensions (`admonition`, `toc`, `tables`, etc.) that were silently overridden when custom extensions were defined — fixes `!!! tip` and other admonitions not rendering
- Add `content.action.edit`, `content.action.view`, and `announce.dismiss` features

## Test plan
- [ ] Run `zensical serve` and verify site title shows "ra-hcp"
- [ ] Verify RA crown logo appears in header
- [ ] Verify GitHub icon + repo link appears beside search
- [ ] Verify homepage renders README.md content (snippet ingestion)
- [ ] Verify `!!! tip` admonitions render correctly on getting-started pages