### PR TITLE
feat: add MinIO service for local S3 development

### DIFF
--- a/.dagger/main.go
+++ b/.dagger/main.go
@@ -13,8 +13,12 @@ const (
 	uvPythonImage = "ghcr.io/astral-sh/uv:0.10.9-python3.13-trixie-slim"
 	denoImage     = "denoland/deno:2.7.1"
 	redisImage    = "redis:8.0.1-alpine"
+	minioImage    = "minio/minio:latest"
 	backendDir    = "backend"
 	frontendDir   = "frontend"
+
+	minioRootUser     = "minioadmin"
+	minioRootPassword = "minioadmin123"
 )
 
 type RaHcp struct{}
@@ -46,5 +50,16 @@ func (m *RaHcp) buildFrontendDev(source *dagger.Directory) *dagger.Container {
 func (m *RaHcp) redis() *dagger.Service {
 	return dag.Container().From(redisImage).
 		WithExposedPort(6379).
+		AsService()
+}
+
+// minio returns a MinIO service with a single default bucket.
+func (m *RaHcp) minio() *dagger.Service {
+	return dag.Container().From(minioImage).
+		WithEnvVariable("MINIO_ROOT_USER", minioRootUser).
+		WithEnvVariable("MINIO_ROOT_PASSWORD", minioRootPassword).
+		WithExposedPort(9000).
+		WithExposedPort(9001).
+		WithExec([]string{"minio", "server", "/data", "--console-address", ":9001"}).
 		AsService()
 }

--- a/.dagger/serve.go
+++ b/.dagger/serve.go
@@ -11,8 +11,12 @@ import (
 // skipKeys are env vars managed by Dagger (service bindings) or intercepted
 // by the Dagger telemetry pipeline. These must not be set from .env.
 var skipKeys = map[string]bool{
-	"REDIS_URL":   true,
-	"BACKEND_URL": true,
+	"REDIS_URL":        true,
+	"BACKEND_URL":      true,
+	"STORAGE_BACKEND":  true,
+	"S3_ENDPOINT_URL":  true,
+	"S3_ACCESS_KEY":    true,
+	"S3_SECRET_KEY":    true,
 }
 
 // skipPrefixes are env var prefixes that Dagger intercepts and routes
@@ -164,6 +168,70 @@ func (m *RaHcp) ServeAll(
 				"socat TCP-LISTEN:5174,fork,reuseaddr TCP:frontend:8000 & " +
 				"wait",
 		}).
+		AsService(), nil
+}
+
+// ServeMinio starts the backend with MinIO as storage, plus Redis.
+// No .env file needed — all config is wired by Dagger.
+func (m *RaHcp) ServeMinio(
+	ctx context.Context,
+	// +defaultPath="/"
+	source *dagger.Directory,
+	// +optional
+	envFile *dagger.File,
+) (*dagger.Service, error) {
+	redisSvc := m.redis()
+	minioSvc := m.minio()
+
+	ctr := m.BuildBackend(source)
+
+	// Apply .env if present (picks up API_SECRET_KEY, etc.)
+	if envFile != nil {
+		var err error
+		ctr, err = applyEnvFile(ctx, ctr, envFile)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// Wire MinIO + Redis via service bindings
+	ctr = ctr.
+		WithServiceBinding("redis", redisSvc).
+		WithEnvVariable("REDIS_URL", "redis://redis:6379").
+		WithServiceBinding("minio", minioSvc).
+		WithEnvVariable("STORAGE_BACKEND", "minio").
+		WithEnvVariable("S3_ENDPOINT_URL", "http://minio:9000").
+		WithEnvVariable("S3_ACCESS_KEY", minioRootUser).
+		WithEnvVariable("S3_SECRET_KEY", minioRootPassword).
+		WithEnvVariable("S3_VERIFY_SSL", "false").
+		WithEnvVariable("S3_ADDRESSING_STYLE", "path").
+		WithEnvVariable("API_SECRET_KEY", "dagger-dev-secret")
+
+	return ctr.
+		WithExposedPort(8000).
+		AsService(), nil
+}
+
+// ServeMinioAll starts the full stack with MinIO: Redis + MinIO + backend + frontend.
+// No .env file needed. Use `up --ports 8000:8000` to access the frontend.
+func (m *RaHcp) ServeMinioAll(
+	ctx context.Context,
+	// +defaultPath="/"
+	source *dagger.Directory,
+	// +optional
+	envFile *dagger.File,
+) (*dagger.Service, error) {
+	backendSvc, err := m.ServeMinio(ctx, source, envFile)
+	if err != nil {
+		return nil, err
+	}
+
+	ctr := m.BuildFrontend(source).
+		WithServiceBinding("backend", backendSvc).
+		WithEnvVariable("BACKEND_URL", "http://backend:8000")
+
+	return ctr.
+		WithExposedPort(8000).
 		AsService(), nil
 }
 

--- a/.docker/docker-compose.yml
+++ b/.docker/docker-compose.yml
@@ -12,18 +12,42 @@ services:
       timeout: 3s
       retries: 3
 
+  minio:
+    image: minio/minio:latest
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    environment:
+      MINIO_ROOT_USER: minioadmin
+      MINIO_ROOT_PASSWORD: minioadmin123
+    volumes:
+      - minio-data:/data
+    command: server /data --console-address ":9001"
+    healthcheck:
+      test: ["CMD", "mc", "ready", "local"]
+      interval: 10s
+      timeout: 3s
+      retries: 3
+
   backend:
     build:
       context: ..
       dockerfile: .docker/backend.dockerfile
     ports:
       - "8000:8000"
-    env_file:
-      - ../.env
     environment:
+      STORAGE_BACKEND: minio
+      S3_ENDPOINT_URL: http://minio:9000
+      S3_ACCESS_KEY: minioadmin
+      S3_SECRET_KEY: minioadmin123
+      S3_VERIFY_SSL: "false"
+      S3_ADDRESSING_STYLE: path
       REDIS_URL: redis://redis:6379
+      API_SECRET_KEY: docker-dev-secret
     depends_on:
       redis:
+        condition: service_healthy
+      minio:
         condition: service_healthy
 
   frontend:
@@ -39,3 +63,4 @@ services:
 
 volumes:
   redis-data:
+  minio-data:


### PR DESCRIPTION
## Summary
- Add MinIO as an S3-compatible storage backend for local development without a real HCP
- Add Dagger functions `serve-minio` and `serve-minio-all` for running the full stack with MinIO
- Update `docker-compose.yml` with MinIO service wired to the backend (`STORAGE_BACKEND=minio`)

## How to use

**Docker Compose:**
```bash
docker compose -f .docker/docker-compose.yml up
```
- Frontend: http://localhost:5174
- Backend API: http://localhost:8000
- MinIO Console: http://localhost:9001 (login: `minioadmin` / `minioadmin123`)

**Dagger:**
```bash
dagger call serve-minio-all --source=. up --ports 8000:8000
```

## Test plan
- [x] `docker compose up` starts all 4 services (redis, minio, backend, frontend)
- [x] All containers report healthy
- [ ] S3 bucket operations work against MinIO via the app UI